### PR TITLE
Fix for new command name

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -82,5 +82,4 @@ cd $p
 go get -tags heroku ./...
 
 mkdir -p $build/bin
-go get github.com/robfig/revel
-go build -o $build/bin/revel github.com/robfig/revel/cmd
+go get github.com/robfig/revel/revel

--- a/bin/compile
+++ b/bin/compile
@@ -77,9 +77,9 @@ mkdir -p $p
 cp -R $build/* $p
 
 unset GIT_DIR # unset git dir or it will mess with goinstall
-echo "-----> Running: go get -v -tags heroku ./..."
+echo "-----> Running: go get -tags heroku ./..."
 cd $p
-go get -v -tags heroku ./...
+go get -tags heroku ./...
 
 mkdir -p $build/bin
 go get github.com/robfig/revel/revel

--- a/bin/compile
+++ b/bin/compile
@@ -77,9 +77,9 @@ mkdir -p $p
 cp -R $build/* $p
 
 unset GIT_DIR # unset git dir or it will mess with goinstall
-echo "-----> Running: go get -tags heroku ./..."
+echo "-----> Running: go get -v -tags heroku ./..."
 cd $p
-go get -tags heroku ./...
+go get -v -tags heroku ./...
 
 mkdir -p $build/bin
 go get github.com/robfig/revel/revel


### PR DESCRIPTION
Since I changed the name of cmd directory, the buildpack broke. I thought of this then, but forgot to update the buildpack.
